### PR TITLE
add tests for in expressions

### DIFF
--- a/acid.sql
+++ b/acid.sql
@@ -583,7 +583,63 @@ select state from sudoku where next=0
 select case when (true
   and (select a as b from (values (1)) t(a) order by b) = 1
 ) then 'T' else 'F' end from (values (1)) AS t
-) testcase(result) UNION ALL select index as test, 'T' as result from generate_series(28,260) s(index) 
+) testcase(result) UNION ALL select 28 as test, result from (
+with
+-- Single IN attribute
+test0  as (select coalesce(sum(k), 0) - 6 as r from (select 1 as k, 1 as x union all select 2, 2 union all select 4, 3) R where x in     (select a from (select 2 as a union all select 3 union all select 4) S)),
+test1  as (select coalesce(sum(k), 0) - 1 as r from (select 1 as k, 1 as x union all select 2, 2 union all select 4, 3) R where x not in (select a from (select 2 as a union all select 3 union all select 4) S)),
+test2  as (select coalesce(sum(k), 0) - 6 as r from (select 1 as k, null as x union all select 2, 2 union all select 4, 3) R where x in     (select a from (select 2 as a union all select 3 union all select 4) S)),
+test3  as (select coalesce(sum(k), 0) - 0 as r from (select 1 as k, null as x union all select 2, 2 union all select 4, 3) R where x not in (select a from (select 2 as a union all select 3 union all select 4) S)),
+test4  as (select coalesce(sum(k), 0) - 6 as r from (select 1 as k, 1 as x union all select 2, 2 union all select 4, 3) R where x in     (select a from (select 2 as a union all select 3 union all select 4 union all select null) S)),
+test5  as (select coalesce(sum(k), 0) - 0 as r from (select 1 as k, 1 as x union all select 2, 2 union all select 4, 3) R where x not in (select a from (select 2 as a union all select 3 union all select 4 union all select null) S)),
+test6  as (select coalesce(sum(k), 0) - 0 as r from (select 1 as k, 1 as x union all select 2, 2 union all select 4, 3) R where x in     (select a from (select 2 as a union all select 3 union all select 4) S where a < 2)),
+test7  as (select coalesce(sum(k), 0) - 7 as r from (select 1 as k, 1 as x union all select 2, 2 union all select 4, 3) R where x not in (select a from (select 2 as a union all select 3 union all select 4) S where a < 2)),
+-- Correlated single IN attribute
+test8  as (select coalesce(sum(k), 0) - 1   as r from (select 1 as k, 1 as x, 1 as y union all select 2, null, 1 union all select 4, 1, 2 union all select 8, null, 2 union all select 16, 1, 3 union all select 32, null, 3 union all select 64, 1, null union all select 128, null, null) R where x in     (select a from (select 1 as a, 1 as b union all select 2, 2) S where y = b)),
+test9  as (select coalesce(sum(k), 0) - 244 as r from (select 1 as k, 1 as x, 1 as y union all select 2, null, 1 union all select 4, 1, 2 union all select 8, null, 2 union all select 16, 1, 3 union all select 32, null, 3 union all select 64, 1, null union all select 128, null, null) R where x not in (select a from (select 1 as a, 1 as b union all select 2, 2) S where y = b)),
+test10 as (select coalesce(sum(k), 0) - 1   as r from (select 1 as k, 1 as x, 1 as y union all select 2, null, 1 union all select 4, 1, 2 union all select 8, null, 2 union all select 16, 1, 3 union all select 32, null, 3 union all select 64, 1, null union all select 128, null, null) R where x in     (select a from (select 1 as a, 1 as b union all select null, 1 union all select null, 2 union all select null, null) S where y = b)),
+test11 as (select coalesce(sum(k), 0) - 240 as r from (select 1 as k, 1 as x, 1 as y union all select 2, null, 1 union all select 4, 1, 2 union all select 8, null, 2 union all select 16, 1, 3 union all select 32, null, 3 union all select 64, 1, null union all select 128, null, null) R where x not in (select a from (select 1 as a, 1 as b union all select null, 1 union all select null, 2 union all select null, null) S where y = b))
+select case when (0
+    + case when (select r from test0)  = 0 then 0 else 1    end
+    + case when (select r from test1)  = 0 then 0 else 2    end
+    + case when (select r from test2)  = 0 then 0 else 4    end
+    + case when (select r from test3)  = 0 then 0 else 8    end
+    + case when (select r from test4)  = 0 then 0 else 16   end
+    + case when (select r from test5)  = 0 then 0 else 32   end
+    + case when (select r from test6)  = 0 then 0 else 64   end
+    + case when (select r from test7)  = 0 then 0 else 128  end
+    + case when (select r from test8)  = 0 then 0 else 256  end
+    + case when (select r from test9)  = 0 then 0 else 512  end
+    + case when (select r from test10) = 0 then 0 else 1024 end
+    + case when (select r from test11) = 0 then 0 else 2048 end) = 0 then 'T' else 'F' end
+from (values (1)) dumm(x)
+) testcase(result) UNION ALL select 29 as test, result from (
+with
+-- Multiple IN attributes
+test0 as (select coalesce(sum(k), 0) - 2  as r from (select 1 as k, 1 as x, 5 as y union all select 2, 2, 6 union all select 4, 3, 9 union all select 8, 9, 8 union all select 16, 3, null union all select 32, null, 8) R where (x, y) in     (select a, b from (select 2 as a, 6 as b union all select 3, 7 union all select 4, 8) S)),
+test1 as (select coalesce(sum(k), 0) - 13 as r from (select 1 as k, 1 as x, 5 as y union all select 2, 2, 6 union all select 4, 3, 9 union all select 8, 9, 8 union all select 16, 3, null union all select 32, null, 8) R where (x, y) not in (select a, b from (select 2 as a, 6 as b union all select 3, 7 union all select 4, 8) S)),
+test2 as (select coalesce(sum(k), 0) - 2  as r from (select 1 as k, 1 as x, 5 as y union all select 2, 2, 6 union all select 4, 3, 9 union all select 8, 9, 8 union all select 16, 3, null union all select 32, null, 8 union all select 64, null, null) R where (x, y) in     (select a, b from (select 2 as a, 6 as b union all select 3, 7 union all select 3, null union all select 4, 8) S)),
+test3 as (select coalesce(sum(k), 0) - 9  as r from (select 1 as k, 1 as x, 5 as y union all select 2, 2, 6 union all select 4, 3, 9 union all select 8, 9, 8 union all select 16, 3, null union all select 32, null, 8 union all select 64, null, null) R where (x, y) not in (select a, b from (select 2 as a, 6 as b union all select 3, 7 union all select 3, null union all select 4, 8) S)),
+test4 as (select coalesce(sum(k), 0) - 2  as r from (select 1 as k, 1 as x, 5 as y union all select 2, 2, 6 union all select 4, 3, 7 union all select 8, 4, 8) R where (x, y) in     (select a, b from (select 2 as a, 6 as b union all select null, 7 union all select 4, null union all select null, null) S)),
+test5 as (select coalesce(sum(k), 0) - 0  as r from (select 1 as k, 1 as x, 5 as y union all select 2, 2, 6 union all select 4, 3, 7 union all select 8, 4, 8) R where (x, y) not in (select a, b from (select 2 as a, 6 as b union all select null, 7 union all select 4, null union all select null, null) S)),
+test6 as (select coalesce(sum(k), 0) - 1  as r from (select 1 as k, 1 as x0, 1 as x1, 1 as x2, 1 as x3, 1 as x4, 1 as x5 union all select 2, 0, 0, 0, 0, 0, 0 union all select 4, 1, 0, 0, 0, 0, 0 union all select 8, 0, 1, 1, 0, 1, 0) R where (x0, x1, x2, x3, x4, x5) in     (select a0, a1, a2, a3, a4, a5 from (select 1 as a0, 1 as a1, 1 as a2, 1 as a3, 1 as a4, 1 as a5 union all select 0, null, null, 0, null, 0) S)),
+test7 as (select coalesce(sum(k), 0) - 4  as r from (select 1 as k, 1 as x0, 1 as x1, 1 as x2, 1 as x3, 1 as x4, 1 as x5 union all select 2, 0, 0, 0, 0, 0, 0 union all select 4, 1, 0, 0, 0, 0, 0 union all select 8, 0, 1, 1, 0, 1, 0) R where (x0, x1, x2, x3, x4, x5) not in (select a0, a1, a2, a3, a4, a5 from (select 1 as a0, 1 as a1, 1 as a2, 1 as a3, 1 as a4, 1 as a5 union all select 0, null, null, 0, null, 0) S)),
+-- Correlated multiple IN attributes
+test8 as (select coalesce(sum(k), 0) - 1  as r from (select 1 as k, 2 as rc, 1 as x0, 1 as x1, 1 as x2, 1 as x3, 1 as x4, 1 as x5 union all select 2, 2, null, null, null, null, null, null union all select 4, 3, 1, 0, 0, 0, 0, 0 union all select 8, 2, 0, 1, 1, 0, 1, 0) R where (x0, x1, x2, x3, x4, x5) in     (select a0, a1, a2, a3, a4, a5 from (select 2 as sc, 1 as a0, 1 as a1, 1 as a2, 1 as a3, 1 as a4, 1 as a5 union all select 3, 0, null, null, 0, null, 0) S where rc = sc)),
+test9 as (select coalesce(sum(k), 0) - 12 as r from (select 1 as k, 2 as rc, 1 as x0, 1 as x1, 1 as x2, 1 as x3, 1 as x4, 1 as x5 union all select 2, 2, null, null, null, null, null, null union all select 4, 3, 1, 0, 0, 0, 0, 0 union all select 8, 2, 0, 1, 1, 0, 1, 0) R where (x0, x1, x2, x3, x4, x5) not in (select a0, a1, a2, a3, a4, a5 from (select 2 as sc, 1 as a0, 1 as a1, 1 as a2, 1 as a3, 1 as a4, 1 as a5 union all select 3, 0, null, null, 0, null, 0) S where rc = sc))
+select case when (0
+    + case when (select r from test0) = 0 then 0 else 1   end
+    + case when (select r from test1) = 0 then 0 else 2   end
+    + case when (select r from test2) = 0 then 0 else 4   end
+    + case when (select r from test3) = 0 then 0 else 8   end
+    + case when (select r from test4) = 0 then 0 else 16  end
+    + case when (select r from test5) = 0 then 0 else 32  end
+    + case when (select r from test6) = 0 then 0 else 64  end
+    + case when (select r from test7) = 0 then 0 else 128 end
+    + case when (select r from test8) = 0 then 0 else 256 end
+    + case when (select r from test9) = 0 then 0 else 512 end) = 0 then 'T' else 'F' end
+from (values (1)) dumm(x)
+) testcase(result) UNION ALL select index as test, 'T' as result from generate_series(30,260) s(index) 
 )
 -- render the result
 select case when state = 1048575 then image else 'XXXXXXXXXXXXXXXXXXXX' end as output from (values

--- a/tests/compliance/test028.sql
+++ b/tests/compliance/test028.sql
@@ -1,0 +1,30 @@
+with
+-- Single IN attribute
+test0  as (select coalesce(sum(k), 0) - 6 as r from (select 1 as k, 1 as x union all select 2, 2 union all select 4, 3) R where x in     (select a from (select 2 as a union all select 3 union all select 4) S)),
+test1  as (select coalesce(sum(k), 0) - 1 as r from (select 1 as k, 1 as x union all select 2, 2 union all select 4, 3) R where x not in (select a from (select 2 as a union all select 3 union all select 4) S)),
+test2  as (select coalesce(sum(k), 0) - 6 as r from (select 1 as k, null as x union all select 2, 2 union all select 4, 3) R where x in     (select a from (select 2 as a union all select 3 union all select 4) S)),
+test3  as (select coalesce(sum(k), 0) - 0 as r from (select 1 as k, null as x union all select 2, 2 union all select 4, 3) R where x not in (select a from (select 2 as a union all select 3 union all select 4) S)),
+test4  as (select coalesce(sum(k), 0) - 6 as r from (select 1 as k, 1 as x union all select 2, 2 union all select 4, 3) R where x in     (select a from (select 2 as a union all select 3 union all select 4 union all select null) S)),
+test5  as (select coalesce(sum(k), 0) - 0 as r from (select 1 as k, 1 as x union all select 2, 2 union all select 4, 3) R where x not in (select a from (select 2 as a union all select 3 union all select 4 union all select null) S)),
+test6  as (select coalesce(sum(k), 0) - 0 as r from (select 1 as k, 1 as x union all select 2, 2 union all select 4, 3) R where x in     (select a from (select 2 as a union all select 3 union all select 4) S where a < 2)),
+test7  as (select coalesce(sum(k), 0) - 7 as r from (select 1 as k, 1 as x union all select 2, 2 union all select 4, 3) R where x not in (select a from (select 2 as a union all select 3 union all select 4) S where a < 2)),
+-- Correlated single IN attribute
+test8  as (select coalesce(sum(k), 0) - 1   as r from (select 1 as k, 1 as x, 1 as y union all select 2, null, 1 union all select 4, 1, 2 union all select 8, null, 2 union all select 16, 1, 3 union all select 32, null, 3 union all select 64, 1, null union all select 128, null, null) R where x in     (select a from (select 1 as a, 1 as b union all select 2, 2) S where y = b)),
+test9  as (select coalesce(sum(k), 0) - 244 as r from (select 1 as k, 1 as x, 1 as y union all select 2, null, 1 union all select 4, 1, 2 union all select 8, null, 2 union all select 16, 1, 3 union all select 32, null, 3 union all select 64, 1, null union all select 128, null, null) R where x not in (select a from (select 1 as a, 1 as b union all select 2, 2) S where y = b)),
+test10 as (select coalesce(sum(k), 0) - 1   as r from (select 1 as k, 1 as x, 1 as y union all select 2, null, 1 union all select 4, 1, 2 union all select 8, null, 2 union all select 16, 1, 3 union all select 32, null, 3 union all select 64, 1, null union all select 128, null, null) R where x in     (select a from (select 1 as a, 1 as b union all select null, 1 union all select null, 2 union all select null, null) S where y = b)),
+test11 as (select coalesce(sum(k), 0) - 240 as r from (select 1 as k, 1 as x, 1 as y union all select 2, null, 1 union all select 4, 1, 2 union all select 8, null, 2 union all select 16, 1, 3 union all select 32, null, 3 union all select 64, 1, null union all select 128, null, null) R where x not in (select a from (select 1 as a, 1 as b union all select null, 1 union all select null, 2 union all select null, null) S where y = b))
+select case when (0
+    + case when (select r from test0)  = 0 then 0 else 1    end
+    + case when (select r from test1)  = 0 then 0 else 2    end
+    + case when (select r from test2)  = 0 then 0 else 4    end
+    + case when (select r from test3)  = 0 then 0 else 8    end
+    + case when (select r from test4)  = 0 then 0 else 16   end
+    + case when (select r from test5)  = 0 then 0 else 32   end
+    + case when (select r from test6)  = 0 then 0 else 64   end
+    + case when (select r from test7)  = 0 then 0 else 128  end
+    + case when (select r from test8)  = 0 then 0 else 256  end
+    + case when (select r from test9)  = 0 then 0 else 512  end
+    + case when (select r from test10) = 0 then 0 else 1024 end
+    + case when (select r from test11) = 0 then 0 else 2048 end) = 0 then 'T' else 'F' end
+from (values (1)) dumm(x)
+;

--- a/tests/compliance/test029.sql
+++ b/tests/compliance/test029.sql
@@ -1,0 +1,26 @@
+with
+-- Multiple IN attributes
+test0 as (select coalesce(sum(k), 0) - 2  as r from (select 1 as k, 1 as x, 5 as y union all select 2, 2, 6 union all select 4, 3, 9 union all select 8, 9, 8 union all select 16, 3, null union all select 32, null, 8) R where (x, y) in     (select a, b from (select 2 as a, 6 as b union all select 3, 7 union all select 4, 8) S)),
+test1 as (select coalesce(sum(k), 0) - 13 as r from (select 1 as k, 1 as x, 5 as y union all select 2, 2, 6 union all select 4, 3, 9 union all select 8, 9, 8 union all select 16, 3, null union all select 32, null, 8) R where (x, y) not in (select a, b from (select 2 as a, 6 as b union all select 3, 7 union all select 4, 8) S)),
+test2 as (select coalesce(sum(k), 0) - 2  as r from (select 1 as k, 1 as x, 5 as y union all select 2, 2, 6 union all select 4, 3, 9 union all select 8, 9, 8 union all select 16, 3, null union all select 32, null, 8 union all select 64, null, null) R where (x, y) in     (select a, b from (select 2 as a, 6 as b union all select 3, 7 union all select 3, null union all select 4, 8) S)),
+test3 as (select coalesce(sum(k), 0) - 9  as r from (select 1 as k, 1 as x, 5 as y union all select 2, 2, 6 union all select 4, 3, 9 union all select 8, 9, 8 union all select 16, 3, null union all select 32, null, 8 union all select 64, null, null) R where (x, y) not in (select a, b from (select 2 as a, 6 as b union all select 3, 7 union all select 3, null union all select 4, 8) S)),
+test4 as (select coalesce(sum(k), 0) - 2  as r from (select 1 as k, 1 as x, 5 as y union all select 2, 2, 6 union all select 4, 3, 7 union all select 8, 4, 8) R where (x, y) in     (select a, b from (select 2 as a, 6 as b union all select null, 7 union all select 4, null union all select null, null) S)),
+test5 as (select coalesce(sum(k), 0) - 0  as r from (select 1 as k, 1 as x, 5 as y union all select 2, 2, 6 union all select 4, 3, 7 union all select 8, 4, 8) R where (x, y) not in (select a, b from (select 2 as a, 6 as b union all select null, 7 union all select 4, null union all select null, null) S)),
+test6 as (select coalesce(sum(k), 0) - 1  as r from (select 1 as k, 1 as x0, 1 as x1, 1 as x2, 1 as x3, 1 as x4, 1 as x5 union all select 2, 0, 0, 0, 0, 0, 0 union all select 4, 1, 0, 0, 0, 0, 0 union all select 8, 0, 1, 1, 0, 1, 0) R where (x0, x1, x2, x3, x4, x5) in     (select a0, a1, a2, a3, a4, a5 from (select 1 as a0, 1 as a1, 1 as a2, 1 as a3, 1 as a4, 1 as a5 union all select 0, null, null, 0, null, 0) S)),
+test7 as (select coalesce(sum(k), 0) - 4  as r from (select 1 as k, 1 as x0, 1 as x1, 1 as x2, 1 as x3, 1 as x4, 1 as x5 union all select 2, 0, 0, 0, 0, 0, 0 union all select 4, 1, 0, 0, 0, 0, 0 union all select 8, 0, 1, 1, 0, 1, 0) R where (x0, x1, x2, x3, x4, x5) not in (select a0, a1, a2, a3, a4, a5 from (select 1 as a0, 1 as a1, 1 as a2, 1 as a3, 1 as a4, 1 as a5 union all select 0, null, null, 0, null, 0) S)),
+-- Correlated multiple IN attributes
+test8 as (select coalesce(sum(k), 0) - 1  as r from (select 1 as k, 2 as rc, 1 as x0, 1 as x1, 1 as x2, 1 as x3, 1 as x4, 1 as x5 union all select 2, 2, null, null, null, null, null, null union all select 4, 3, 1, 0, 0, 0, 0, 0 union all select 8, 2, 0, 1, 1, 0, 1, 0) R where (x0, x1, x2, x3, x4, x5) in     (select a0, a1, a2, a3, a4, a5 from (select 2 as sc, 1 as a0, 1 as a1, 1 as a2, 1 as a3, 1 as a4, 1 as a5 union all select 3, 0, null, null, 0, null, 0) S where rc = sc)),
+test9 as (select coalesce(sum(k), 0) - 12 as r from (select 1 as k, 2 as rc, 1 as x0, 1 as x1, 1 as x2, 1 as x3, 1 as x4, 1 as x5 union all select 2, 2, null, null, null, null, null, null union all select 4, 3, 1, 0, 0, 0, 0, 0 union all select 8, 2, 0, 1, 1, 0, 1, 0) R where (x0, x1, x2, x3, x4, x5) not in (select a0, a1, a2, a3, a4, a5 from (select 2 as sc, 1 as a0, 1 as a1, 1 as a2, 1 as a3, 1 as a4, 1 as a5 union all select 3, 0, null, null, 0, null, 0) S where rc = sc))
+select case when (0
+    + case when (select r from test0) = 0 then 0 else 1   end
+    + case when (select r from test1) = 0 then 0 else 2   end
+    + case when (select r from test2) = 0 then 0 else 4   end
+    + case when (select r from test3) = 0 then 0 else 8   end
+    + case when (select r from test4) = 0 then 0 else 16  end
+    + case when (select r from test5) = 0 then 0 else 32  end
+    + case when (select r from test6) = 0 then 0 else 64  end
+    + case when (select r from test7) = 0 then 0 else 128 end
+    + case when (select r from test8) = 0 then 0 else 256 end
+    + case when (select r from test9) = 0 then 0 else 512 end) = 0 then 'T' else 'F' end
+from (values (1)) dumm(x)
+;


### PR DESCRIPTION
The standard defines IN expressions as equivalent to =ANY expressions, which are themselves defined under `<quantified comparison predicate>`. The quantified comparisons use ternary logic. The handling of ternary logic is complicated, confusing, and error prone.  So we add tests for compliance to see whether systems handle IN expressions correctly.

We separate the tests into those with a single attribute and those with row expressions as there are many systems that only support IN expressions with a single attribute.

Here are our manual runs on various systems:

Tests:
1: single attribute, not correlated
2: single attribute, correlated
3: multiple attributes, not correlated
4: multiple attributes, correlated
The numbers in parantheses are bit vectors representing failed test subcases.

Clickhouse 25.8:
Wrong 1(32), 3(170)
Unsupported 2, 4 (Enable 'allow_experimental_correlated_subqueries' setting to allow correlated subqueries execution)

Hyper 9.1.0:
Wrong 1(40), 2(10)
Unsupported 3, 4

DuckDB 1.3.0:
Correct 1, 2
Wrong 3(136)
Unsupported 4

Redshift 1.0.118447:
Correct 1, 2, 3
Wrong 4(2)

Snowflake 9.21.0:
Correct 1, 2, 4
Wrong 3(136)

Firebolt Core 4.23.5:
Correct 1, 2, 4
Wrong 3(170)

BigQuery 2025-07-22:
Correct 1, 2
Unsupported 3, 4

Sqlserver 2022:
Correct 1, 2
Unsupported 3, 4

Databricks 2025.16:
Correct 1, 2, 3, 4

CedarDB v2025-07-23:
Correct 1, 2, 3, 4

Sqlite 3.46.1:
Correct 1, 2, 3, 4

Umbra 25.01:
Correct 1, 2, 3, 4

DB2 Developer-C 11.1:
Correct 1, 2, 3, 4

MariaDB 11.4:
Correct 1, 2, 3, 4

Oracle 23c:
Correct 1, 2, 3, 4

Postgres 17:
Correct 1, 2, 3, 4

TimescaleDB 2.14:
Correct 1, 2, 3, 4

YugabyteDB 2.18:
Correct 1, 2, 3, 4

Materialize v0.151.0:
Correct 1, 2, 3, 4

PrestoDB 0.294-870b94b:
Correct 1, 2
Unsupported 3, 4

Note that I tested systems with 2 different versions of the queries, one with `VALUES` and another with `UNION ALL`. I picked the results that each system complained least about.